### PR TITLE
Fix static plot generation issue caused by Kaleido's internet requirement

### DIFF
--- a/nanoplotter/nanoplotter_main.py
+++ b/nanoplotter/nanoplotter_main.py
@@ -144,6 +144,7 @@ def scatter(
 
         dot_plot.fig = fig
         dot_plot.html = dot_plot.fig.to_html(full_html=False, include_plotlyjs="cdn")
+        dot_plot.save_json()
         dot_plot.save(settings)
         plots_made.append(dot_plot)
 
@@ -174,6 +175,7 @@ def scatter(
 
         kde_plot.fig = fig
         kde_plot.html = kde_plot.fig.to_html(full_html=False, include_plotlyjs="cdn")
+        kde_plot.save_json()
         kde_plot.save(settings)
         plots_made.append(kde_plot)
 
@@ -275,6 +277,7 @@ def scatter_legacy(
         plt.subplots_adjust(top=0.90)
         plot.fig.suptitle(title or f"{names[0]} vs {names[1]} plot", fontsize=25)
         hex_plot.fig = plot
+        hex_plot.save_json()
         hex_plot.save(settings)
         plots_made.append(hex_plot)
 
@@ -313,6 +316,7 @@ def scatter_legacy(
         plt.subplots_adjust(top=0.90)
         plot.fig.suptitle(title or "{} vs {} plot".format(names[0], names[1]), fontsize=25)
         dot_plot.fig = plot
+        dot_plot.save_json()
         dot_plot.save(settings)
         plots_made.append(dot_plot)
 
@@ -352,6 +356,7 @@ def scatter_legacy(
             plt.subplots_adjust(top=0.90)
             plot.fig.suptitle(title or "{} vs {} plot".format(names[0], names[1]), fontsize=25)
             kde_plot.fig = plot
+            kde_plot.save_json()
             kde_plot.save(settings)
             plots_made.append(kde_plot)
         else:
@@ -451,6 +456,7 @@ def length_plots(array, name, path, settings, title=None, n50=None, color="#4CB3
 
         histogram.fig = fig
         histogram.html = histogram.fig.to_html(full_html=False, include_plotlyjs="cdn")
+        histogram.save_json()
         histogram.save(settings)
 
         log_histogram = Plot(
@@ -502,6 +508,7 @@ def length_plots(array, name, path, settings, title=None, n50=None, color="#4CB3
 
         log_histogram.fig = fig
         log_histogram.html = log_histogram.fig.to_html(full_html=False, include_plotlyjs="cdn")
+        log_histogram.save_json()
         log_histogram.save(settings)
 
         plots.extend([histogram, log_histogram])
@@ -573,6 +580,7 @@ def yield_by_minimal_length_plot(array, name, path, settings, title=None, color=
 
     yield_by_length.fig = fig
     yield_by_length.html = yield_by_length.fig.to_html(full_html=False, include_plotlyjs="cdn")
+    yield_by_length.save_json()
     yield_by_length.save(settings)
 
     return yield_by_length

--- a/nanoplotter/plot.py
+++ b/nanoplotter/plot.py
@@ -5,6 +5,7 @@ from urllib.parse import quote as urlquote
 import sys
 from kaleido.scopes.plotly import PlotlyScope
 import logging
+import plotly.io as pio
 
 
 class Plot(object):
@@ -47,7 +48,7 @@ class Plot(object):
                 if not settings["no_static"]:
                     try:
                         for fmt in settings["format"]:
-                            self.save_static(fmt)
+                            self.save_static2(fmt)
                     except (AttributeError, ValueError) as e:
                         p = os.path.splitext(self.path)[0] + ".png"
                         if os.path.exists(p):
@@ -83,3 +84,40 @@ class Plot(object):
             logging.info(
                 f"Saved {self.path.replace('.html', '')}  as {figformat} (or png for --legacy)"
             )
+    
+    
+    def save_static2(self, figformat):
+        json_fig = pio.read_json(self.path.replace("html", "json"))
+        json_fig.write_image(self.path.replace("html", figformat), format=figformat)
+        logging.info(
+                f"Saved {self.path.replace('.html', '')}  as {figformat} (or png for --legacy)"
+            )
+
+
+    
+    def save_json(self, json_path=None):
+        """
+        将 fig 对象保存为 JSON 文件。
+        
+        参数:
+            json_path (str): JSON 文件的路径。如果未指定，则基于 self.path 构造路径。
+        """
+        if not self.fig:
+            logging.error("无法保存 JSON 文件：fig 对象为空")
+            return
+        
+        # 如果未指定 json_path，则基于 self.path 构造默认路径
+        if json_path is None:
+            json_path = self.path.replace(".html", ".json")  # 替换 .html 为 .json
+        
+        try:
+            # 将 fig 对象导出为 JSON 数据
+            json_data = self.fig.to_json()
+
+            # 写入 JSON 文件
+            with open(json_path, "w", encoding="utf-8") as f:
+                f.write(json_data)
+
+            logging.info(f"成功保存 JSON 文件: {json_path}")
+        except Exception as e:
+            logging.error(f"保存 JSON 文件失败: {e}")


### PR DESCRIPTION
#### Summary:
This PR addresses an intermittent failure in generating static plots due to the dependency on an internet connection when using Kaleido, a Python package that converts HTML to PNG. The fix ensures that static plots can be generated offline by utilizing JSON data alongside HTML files.

#### Problem Description:
`No static plots are saved due to some kaleido problem`
The Python package Kaleido requires an internet connection to convert HTML content into PNG images. This has led to failures in generating static plots when working in environments without network access.

#### Solution Overview:
To resolve this issue, the following changes have been implemented:

1. **Generate JSON Files During Plot Creation**:
   - In addition to generating HTML files, the system now also generates corresponding JSON files containing all necessary plot information.
   
2. **Utilize Plotly for Static Plot Generation from JSON Data**:
   - By leveraging the Plotly Python library, static plots are created directly from the generated JSON data. This approach bypasses the need for Kaleido and its dependency on an internet connection.

#### Implementation Details:
- **Changes in Code**:
  - Added functionality to export JSON files whenever HTML files are generated.
  - Modified the plot generation process to use Plotly to render static plots based on JSON data.
  
- **Testing**:
  - Verified that static plots can now be successfully generated both online and offline.
  - Ensured compatibility with existing workflows and configurations.

#### Additional Notes:
- This change should not introduce any breaking changes but rather provides a more robust solution for generating static plots under varying network conditions.
- It is recommended to thoroughly test these changes in different scenarios before merging to ensure they meet all project requirements.

#### Checklist:
- [x] The code has been tested locally.
- [x] All new and existing tests passed.
- [x] Documentation updated if necessary.

