### PR TITLE
Fix histogram ylabel for weighted plots

### DIFF
--- a/nanoplotter/nanoplotter_main.py
+++ b/nanoplotter/nanoplotter_main.py
@@ -398,7 +398,7 @@ def length_plots(array, name, path, settings, title=None, n50=None, color="#4CB3
     plots = []
 
     HistType = [
-        {"weight": array, "name": "Weighted", "ylabel": "Number of bases"},
+        {"weight": array, "name": "Weighted", "ylabel": "Number of reads"},
         {"weight": None, "name": "Non weighted", "ylabel": "Number of reads"},
     ]
 


### PR DESCRIPTION
Hello there, 

I just used your tool to check simulated reads and saw what I think is a typo in the ylabel of the wheighted histogram of read length distribution. 
I thought it was weird to compare the number of **bases** to read length given it's basically the same thing. Furthermore, it's not what the big title says.

So I here's my lil' fix.

Tell me if I was mistaken !

Have a nice day